### PR TITLE
Added authorizer to the request mapping for aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ module.exports.handler = endpoint(getHelloWorld)
 | apiId | <code>string</code> | `AWS Only` string apiId: AWS.event.requestContext.apiId |
 | stage | <code>string</code> | `AWS Only` api stage from url - /dev/resource = 'dev' |
 | identity | <code>Object</code> | `AWS Only` identity of user: event.requestContext.identity |
+| authorizer | <code>Object</code> | `AWS Only` object returned from custom authorizer: event.requestContext.authorizer |
 | header | <code>function</code> | value for the header key - header(headerKey) |
 | get | <code>function</code> | value for the header key - get(headerKey)
 | getOriginalRequest | <code>function</code> | `AWS Only`returns the arguments provided to the http function |

--- a/lib/endpoint/__tests__/__snapshots__/aws-mapper.js.snap
+++ b/lib/endpoint/__tests__/__snapshots__/aws-mapper.js.snap
@@ -9,6 +9,7 @@ Object {
 exports[`mappers.aws-mapper.js convertEventToRequest should apply sensible defaults for empty event object 1`] = `
 Object {
   "apiId": undefined,
+  "authorizer": Object {},
   "body": Object {},
   "headers": Object {},
   "id": undefined,
@@ -29,6 +30,7 @@ Object {
 exports[`mappers.aws-mapper.js convertEventToRequest should map event to an object res can consume 1`] = `
 Object {
   "apiId": "xxxxxxxxxx",
+  "authorizer": Object {},
   "body": Object {
     "name": "Ethan",
   },

--- a/lib/endpoint/__tests__/req.js
+++ b/lib/endpoint/__tests__/req.js
@@ -45,6 +45,9 @@ describe('endpoint.req.js', () => {
       identity: {
         cognitoId: 'uuid',
         userIP: '192.168.144.144'
+      },
+      authorizer: {
+        principleId: '44223232'
       }
     }, setupData);
     const req = new Req(mappedData);
@@ -53,6 +56,7 @@ describe('endpoint.req.js', () => {
     expect(req.apiId).toBe(mappedData.apiId);
     expect(req.stage).toBe(mappedData.stage);
     expect(req.identity).toBe(mappedData.identity);
+    expect(req.authorizer).toBe(mappedData.authorizer);
   });
 
   test('get function', () => {

--- a/lib/endpoint/mappers/aws-mapper.js
+++ b/lib/endpoint/mappers/aws-mapper.js
@@ -39,6 +39,7 @@ function convertEventToRequest(event, context) {
     apiId: requestContext.apiId,
     stage: requestContext.stage,
     identity: Object.assign({}, identity),
+    authorizer: Object.assign({}, identity),
     provider: 'aws'
   };
 }

--- a/lib/endpoint/mappers/aws-mapper.js
+++ b/lib/endpoint/mappers/aws-mapper.js
@@ -19,6 +19,7 @@ function convertEventToRequest(event, context) {
   // requestContext
   const requestContext = event.requestContext || {};
   const identity = requestContext.identity || {};
+  const authorizer = requestContext.authorizer || {};
 
   const headers = event.headers || {};
   const pathParameters = event.pathParameters || {};
@@ -39,7 +40,7 @@ function convertEventToRequest(event, context) {
     apiId: requestContext.apiId,
     stage: requestContext.stage,
     identity: Object.assign({}, identity),
-    authorizer: Object.assign({}, identity),
+    authorizer: Object.assign({}, authorizer),
     provider: 'aws'
   };
 }

--- a/lib/endpoint/req.js
+++ b/lib/endpoint/req.js
@@ -38,6 +38,7 @@ module.exports = class Req {
     this.apiId = message.apiId;
     this.stage = message.stage;
     this.identity = message.identity;
+    this.authorizer = message.authorizer;
 
 
     // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
Found that I couldn't access the principleId from the current request mapping. I have added the mapping for aws endpoints so you can now access it from the req.

Sample event:
```
{ headers: 
   { 'Cache-Control': 'no-cache',
     'Postman-Token': 'dec0349e-1e0c-4788-ac53-1b51b1c3c8ed',
     Authorization: 'bearer **token**',
     'User-Agent': 'PostmanRuntime/3.0.9',
     Accept: '*/*',
     Host: 'localhost:3000',
     'Accept-Encoding': 'gzip, deflate',
     Connection: 'keep-alive' },
  path: '/3',
  pathParameters: { id: '3' },
  requestContext: 
   { accountId: 'offlineContext_accountId',
     resourceId: 'offlineContext_resourceId',
     stage: 'ci',
     requestId: 'offlineContext_requestId_',
     identity: 
      { cognitoIdentityPoolId: 'offlineContext_cognitoIdentityPoolId',
        accountId: 'offlineContext_accountId',
        cognitoIdentityId: 'offlineContext_cognitoIdentityId',
        caller: 'offlineContext_caller',
        apiKey: 'offlineContext_apiKey',
        sourceIp: '127.0.0.1',
        cognitoAuthenticationType: 'offlineContext_cognitoAuthenticationType',
        cognitoAuthenticationProvider: 'offlineContext_cognitoAuthenticationProvider',
        userArn: 'offlineContext_userArn',
        userAgent: 'PostmanRuntime/3.0.9',
        user: 'offlineContext_user' },
     authorizer: { principalId: 'email|58c08176879f18288a*****' },
     resourcePath: '/{id}',
     httpMethod: 'GET' },
  resource: '/{id}',
  httpMethod: 'GET',
  queryStringParameters: null,
  body: null,
  stageVariables: null,
  isOffline: true }
```